### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/.github/config/.tsqllintrc
+++ b/.github/config/.tsqllintrc
@@ -26,7 +26,6 @@
         "unicode-string": "error"
     },
     "plugins": {
-        "wtw-custom-rules": "./.github/config/tsqllint-customrules.dll"
     },
     "compatability-level": 140
 }

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -16,8 +16,12 @@ jobs:
           node-version: '16'
 
       - name: Test
+        id: test
         uses: ./
         with:
           path-to-sql-files: ./.github/workflows/test-sql-files
           file-name-filter: ShouldSucceed.sql
           path-to-lint-config: ./.github/config/.tsqllintrc
+      
+      - name: Print Lint Result
+        run: echo '${{ steps.test.outputs.lint-result }}'

--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ jobs:
 
       - id: sql-file-folder
         shell: pwsh
-        run: echo "::set-output name=folder::$($(Get-Date).Year).$($(Get-Date).Month.ToString("00"))"
+        run: |
+          folderName=$($(Get-Date).Year).$($(Get-Date).Month.ToString("00"))
+          echo "folder=$folderName" >> $GITHUB_OUTPUT
 
       - name: SQL Lint
-        uses: im-open/tsql-lint-action@v1.0.5
+        uses: im-open/tsql-lint-action@v1.1.0
         with:
           tsqllint-version: 1.11.0
           path-to-sql-files: "Database/src/Migrations/${{ steps.sql-file-folder.outputs.folder }}"

--- a/README.md
+++ b/README.md
@@ -77,12 +77,16 @@ jobs:
           echo "folder=$folderName" >> $GITHUB_OUTPUT
 
       - name: SQL Lint
+        id: sql-lint
         uses: im-open/tsql-lint-action@v1.1.0
         with:
           tsqllint-version: 1.11.0
           path-to-sql-files: "Database/src/Migrations/${{ steps.sql-file-folder.outputs.folder }}"
           file-name-filter: "*.sql"
           path-to-lint-config: ./Database/src/.tsqllintrc
+      
+      - name: Print Lint Result
+        run: echo '${{ steps.sql-lint.outputs.lint-result }}'
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
 outputs:
   lint-result:
     description: The result of the lint run.
-    value: ${{ steps.run-lint.outputs.result }}
+    value: ${{ steps.run-lint.outputs.LINT_RESULT }}
 
 runs:
   using: 'composite'
@@ -33,11 +33,15 @@ runs:
       id: config-file-path
       shell: pwsh
       run: |
+        # The syntax for setting outputs/envs in pwsh is slightly different than bash, for pwsh use:  "name=value" >> $env:GITHUB_OUTPUT
+
         if ([string]::IsNullOrEmpty("${{ inputs.path-to-lint-config }}") -or !(Test-Path ${{ inputs.path-to-lint-config }})) {
-          echo "path=${{ github.action_path }}/.tsqllintrc" >> $GITHUB_OUTPUT
+          Write-Host "Default to using the built in .tsllintrc file"
+          "path=${{ github.action_path }}/.tsqllintrc" >> $env:GITHUB_OUTPUT
         }
         else {
-          echo "path=${{ inputs.path-to-lint-config }}" >> $GITHUB_OUTPUT
+          Write-Host "Use the provided lint config file"
+          "path=${{ inputs.path-to-lint-config }}" >> $env:GITHUB_OUTPUT
         }
 
     - name: Run tsqllint
@@ -68,4 +72,8 @@ runs:
           Write-Host $Result
         }
 
-        echo "result=$(echo $Result)" >> $GITHUB_OUTPUT
+        # The syntax for setting outputs/envs in pwsh is slightly different than bash, for pwsh use:  "name=value" >> $env:GITHUB_OUTPUT
+        # Since this is a multi-line result, it also has to be escaped slightly differently.
+        'LINT_RESULT<<EOF' >> $env:GITHUB_OUTPUT
+        "$Result" >> $env:GITHUB_OUTPUT
+        'EOF' >> $env:GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -34,10 +34,10 @@ runs:
       shell: pwsh
       run: |
         if ([string]::IsNullOrEmpty("${{ inputs.path-to-lint-config }}") -or !(Test-Path ${{ inputs.path-to-lint-config }})) {
-          echo "::set-output name=path::${{ github.action_path }}/.tsqllintrc"
+          echo "path=${{ github.action_path }}/.tsqllintrc" >> $GITHUB_OUTPUT
         }
         else {
-          echo "::set-output name=path::${{ inputs.path-to-lint-config }}"
+          echo "path=${{ inputs.path-to-lint-config }}" >> $GITHUB_OUTPUT
         }
 
     - name: Run tsqllint
@@ -68,4 +68,4 @@ runs:
           Write-Host $Result
         }
 
-        echo "::set-output name=result::$(echo $Result)"
+        echo "result=$(echo $Result)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
